### PR TITLE
fix: Renderデプロイエラー修正 - cacheテーブル不存在問題の解決

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,12 @@ chown -R www-data:www-data /var/www/html/database/
 chmod 775 /var/www/html/database/
 chmod 664 /var/www/html/database/database.sqlite
 
-# キャッシュクリア
+# データベースマイグレーション（最優先で実行）
+echo "Running database migrations..."
+php artisan migrate --force
+
+# キャッシュクリア（マイグレーション後に実行）
+echo "Clearing Laravel caches..."
 php artisan config:clear
 php artisan cache:clear
 php artisan view:clear
@@ -28,10 +33,6 @@ if [ "$APP_ENV" = "production" ]; then
     php artisan route:cache
     php artisan view:cache
 fi
-
-# データベースマイグレーション
-echo "Running database migrations..."
-php artisan migrate --force
 
 # データベースシード（本番環境でも基本データは必要）
 if [ -f /var/www/html/database/seeders/DatabaseSeeder.php ]; then

--- a/render.yaml
+++ b/render.yaml
@@ -24,7 +24,7 @@ services:
         value: sqlite
       - key: DB_DATABASE
         value: /var/www/html/database/database.sqlite
-      - key: CACHE_DRIVER
+      - key: CACHE_STORE
         value: file
       - key: SESSION_DRIVER
         value: file
@@ -35,10 +35,10 @@ services:
       - key: LOG_LEVEL
         value: error
     buildCommand: |
-      # Laravel初期化コマンドをビルド時に実行
+      # Laravel初期化コマンド（マイグレーション優先実行）
+      php artisan migrate --force
+      php artisan db:seed --force
       php artisan config:cache
       php artisan route:cache
       php artisan view:cache
-      php artisan migrate --force
-      php artisan db:seed --force
     startCommand: /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
問題: デプロイ時に「no such table: cache」エラーが発生
原因: キャッシュクリア処理がマイグレーション実行前に実行されていた

修正内容:
- docker/entrypoint.sh: マイグレーションを最優先で実行
- render.yaml: buildCommandでマイグレーション→シード→キャッシュの順序に変更
- .env.production: CACHE_DRIVERとCACHE_STOREを明示的にfileに設定

実行順序:
1. php artisan migrate --force (最優先)
2. php artisan db:seed --force
3. php artisan cache:clear (テーブル作成後)
4. 本番用キャッシュ設定

これによりRender.comデプロイ時のcacheテーブル不存在エラーを解決

🔧 Generated with [Claude Code](https://claude.ai/code)