### PR TITLE
Fix deployment build error and optimize Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,46 @@
+# Git関連
 .git
 .gitignore
+
+# ドキュメント関連
 README.md
+*.md
+docs/
+AUTHENTICATION_SETUP.md
+DOCKER_README.md
+GOOGLE_OAUTH_SETUP.md
+SUPABASE_SETUP.md
+development_setup_guide.md
+dev-server.md
+ui_ux_design.md
+
+# 環境変数
 .env
 .env.backup
+.env.example
+.env.local
+.env.*.local
+
+# テスト関連
+/tests
+phpunit.xml
 .phpunit.result.cache
+phpunit.xml
 Homestead.json
 Homestead.yaml
+
+# Node.js関連
+node_modules
 npm-debug.log
 yarn-error.log
-node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Composer vendor（ビルド前にCOPYするため除外）
 vendor
+
+# Laravel ストレージ・キャッシュ
 storage/logs/*.log
 storage/framework/cache/*
 storage/framework/sessions/*
@@ -18,10 +49,22 @@ storage/framework/views/*
 bootstrap/cache/*
 public/hot
 public/storage
+
+# IDE・エディタ
 .vscode
 .idea
 *.swp
 *.swo
 *~
+
+# OS
 .DS_Store
 Thumbs.db
+
+# Docker関連
+docker-compose.yml
+
+# その他不要ファイル
+*.log
+*.pid
+cookies.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# メモリ効率を重視したDockerfile
-FROM php:8.2-fpm
+# マルチステージビルドでイメージサイズを最小化
+# ビルドステージ
+FROM php:8.2-fpm as build-stage
 
 # 必要最小限のシステム依存関係のみインストール
 RUN apt-get update && apt-get install -y \
@@ -32,16 +33,25 @@ WORKDIR /var/www/html
 COPY composer.json composer.lock ./
 RUN composer install --no-dev --optimize-autoloader --no-interaction --no-scripts
 
-# Node.js依存関係をインストール
+# Node.js依存関係をインストール（ビルド時は全依存関係が必要）
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci
 
 # アプリケーションファイルをコピー
 COPY . .
 
 # フロントエンドをビルド（本番環境用）
 RUN npm run build
-RUN npm cache clean --force
+
+# ビルド後に不要なdev依存関係とキャッシュを削除
+RUN npm prune --production && npm cache clean --force
+
+# 不要なファイルを削除してイメージサイズを削減
+RUN rm -rf node_modules/.cache \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/* \
+    && rm -rf /root/.npm \
+    && rm -rf /root/.composer/cache
 
 # ストレージディレクトリの権限設定
 RUN chown -R www-data:www-data /var/www/html/storage \
@@ -56,6 +66,51 @@ COPY docker/php-fpm/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY docker/nginx/default.conf /etc/nginx/sites-available/default
 
 # Supervisor設定
+COPY docker/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# エントリーポイントスクリプト
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# ポートを公開
+EXPOSE 80
+
+# 本番ステージ（軽量化）
+FROM php:8.2-fpm as production
+
+# 本番用の最小限の依存関係のみインストール
+RUN apt-get update && apt-get install -y \
+    libpng-dev \
+    libonig-dev \
+    libpq-dev \
+    nginx \
+    supervisor \
+    && docker-php-ext-install pdo pdo_pgsql pgsql mbstring gd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/*
+
+# 作業ディレクトリを設定
+WORKDIR /var/www/html
+
+# ビルドステージから必要なファイルのみコピー
+COPY --from=build-stage /var/www/html/vendor ./vendor
+COPY --from=build-stage /var/www/html/public/build ./public/build
+COPY --from=build-stage /var/www/html/bootstrap/cache ./bootstrap/cache
+
+# アプリケーションファイルをコピー（.dockerignoreで不要ファイルは除外）
+COPY . .
+
+# 権限設定
+RUN chown -R www-data:www-data /var/www/html/storage \
+    && chown -R www-data:www-data /var/www/html/bootstrap/cache \
+    && chmod -R 775 /var/www/html/storage \
+    && chmod -R 775 /var/www/html/bootstrap/cache
+
+# 設定ファイルをコピー
+COPY docker/php-fpm/www.conf /usr/local/etc/php-fpm.d/www.conf
+COPY docker/nginx/default.conf /etc/nginx/sites-available/default
 COPY docker/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # エントリーポイントスクリプト

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
         "@tailwindcss/vite": "^4.0.0",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^1.2.0",
-        "tailwindcss": "^4.0.0",
-        "vite": "^6.2.4"
+        "tailwindcss": "^4.0.0"
     },
     "dependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
         "vue": "^3.5.17",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.5.1",
+        "laravel-vite-plugin": "^1.2.0",
+        "vite": "^6.2.4"
     }
 }


### PR DESCRIPTION
- Move laravel-vite-plugin from devDependencies to dependencies to fix build error
- Update Dockerfile to use npm ci instead of npm ci --omit=dev for proper build
- Implement multi-stage build for production optimization
- Enhanced .dockerignore to exclude unnecessary files (tests, docs, logs)
- Add cleanup steps to reduce final image size under 512MB

🤖 Generated with [Claude Code](https://claude.ai/code)