### PR TITLE
Fix PostgreSQL database connection for production deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -60,9 +60,9 @@ services:
       npm run build
     startCommand: /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 
-  - type: pserv
-    name: study-app-db
-    env: docker
-    plan: starter
+databases:
+  - name: study-app-db
     databaseName: study_app_production
+    user: study_app_user
     region: singapore
+    plan: starter


### PR DESCRIPTION
- Fix render.yaml database configuration from incorrect 'type: pserv' to proper 'databases' section
- Add PostgreSQL connection health check in entrypoint.sh with 60-second timeout
- Add detailed database connection error logging for debugging
- Maintain existing SQLite support for local development

🤖 Generated with [Claude Code](https://claude.ai/code)