### PR TITLE
🐛 Fix: Docker環境で400 Bad Request エラーが発生する問題を解決

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -10,10 +10,10 @@ server {
     gzip_comp_level 1;
     gzip_types text/plain text/css application/javascript;
     
-    # バッファサイズを小さく設定
-    client_body_buffer_size 8k;
-    client_header_buffer_size 1k;
-    large_client_header_buffers 2 1k;
+    # バッファサイズを適切に設定
+    client_body_buffer_size 16k;
+    client_header_buffer_size 4k;
+    large_client_header_buffers 4 8k;
 
     # Assets with hash can be cached forever
     location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg)$ {


### PR DESCRIPTION
🔍 問題の概要

  Docker環境で localhost:8000 にブラウザでアクセスすると、以下のエラーが発生していました：

  400 Bad Request
  Request Header Or Cookie Too Large
  nginx/1.22.1

  - curlでのアクセスは正常に動作（200 OK）
  - ブラウザでのアクセスのみ400エラーが発生
  - コンソールにも GET http://localhost:8000/ 400 (Bad Request) が表示

  🔎 原因の分析

  問題の原因は、Nginxのヘッダーバッファサイズ設定が小さすぎることでした：

  # 問題のあった設定
  client_header_buffer_size 1k;
  large_client_header_buffers 2 1k;
  client_body_buffer_size 8k;

  ブラウザは通常、以下のような大きなHTTPヘッダーを送信します：
  - Cookieデータ（セッション、CSRF トークンなど）
  - User-Agent文字列
  - Accept、Accept-Language、Accept-Encoding等の詳細なヘッダー
  - Referer情報
  - その他のブラウザ固有ヘッダー

  これらが合計で1kBを超えるため、Nginxが「ヘッダーが大きすぎる」と判断してリクエストを拒否していました。

  🛠️ 対応内容

  docker/nginx/default.conf のバッファサイズを適切な値に増加：

  # 修正後の設定
  client_header_buffer_size 4k;      # 1k → 4k に増加
  large_client_header_buffers 4 8k;  # 2 1k → 4 8k に増加
  client_body_buffer_size 16k;       # 8k → 16k に増加

  設定値の根拠：
  - client_header_buffer_size 4k: 通常のHTTPヘッダーを格納するのに十分なサイズ
  - large_client_header_buffers 4 8k: 大きなCookieやカスタムヘッダーにも対応
  - client_body_buffer_size 16k: リクエストボディのバッファも余裕を持って設定

  ✅ 検証結果

  - ✅ ブラウザでのアクセスが正常に動作（400エラー解消）
  - ✅ curlでのアクセスも引き続き正常動作
  - ✅ Vue.jsアプリケーションが正常に表示される
  - ✅ APIエンドポイントへのアクセスも正常

  📝 補足

  この問題は特にLaravelアプリケーションで発生しやすい傾向があります：
  - CSRFトークンがCookieに保存される
  - セッションデータが大きくなりがち
  - Laravel Sanctumの認証トークンも影響する可能性

  今回の修正により、本番環境でも同様の問題を回避できます。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Nginx buffer sizes to better handle larger client requests and headers.
  * Updated configuration comments to reflect the new buffer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->