### PR TITLE
fix: 試験タイプ削除時の500エラーを修正

### DIFF
--- a/app/Http/Controllers/Api/StudyGoalController.php
+++ b/app/Http/Controllers/Api/StudyGoalController.php
@@ -64,7 +64,7 @@ class StudyGoalController extends Controller
 
             // セキュリティチェック：ExamType所有権の検証
             if (isset($validated['exam_type_id'])) {
-                if (!$this->validateExamTypeOwnership($validated['exam_type_id'], auth()->id())) {
+                if (! $this->validateExamTypeOwnership($validated['exam_type_id'], auth()->id())) {
                     return response()->json([
                         'success' => false,
                         'message' => '指定された試験タイプへのアクセス権限がありません',
@@ -191,7 +191,7 @@ class StudyGoalController extends Controller
 
             // セキュリティチェック：ExamType所有権の検証
             if (isset($validated['exam_type_id'])) {
-                if (!$this->validateExamTypeOwnership($validated['exam_type_id'], auth()->id())) {
+                if (! $this->validateExamTypeOwnership($validated['exam_type_id'], auth()->id())) {
                     return response()->json([
                         'success' => false,
                         'message' => '指定された試験タイプへのアクセス権限がありません',
@@ -326,11 +326,11 @@ class StudyGoalController extends Controller
 
     /**
      * ExamTypeの所有権を検証
-     * 
+     *
      * セキュリティ強化：他ユーザーのExamTypeへの不正アクセスを防止
-     * 
-     * @param int|null $examTypeId 検証するExamTypeのID（nullの場合は検証スキップ）
-     * @param int $userId 所有権を確認するユーザーID
+     *
+     * @param  int|null  $examTypeId  検証するExamTypeのID（nullの場合は検証スキップ）
+     * @param  int  $userId  所有権を確認するユーザーID
      * @return bool 所有権がある場合true、ない場合false
      */
     private function validateExamTypeOwnership(?int $examTypeId, int $userId): bool
@@ -347,7 +347,7 @@ class StudyGoalController extends Controller
 
     /**
      * StudyGoalの試験日をExamTypeに同期
-     * 
+     *
      * 同期条件：
      * - exam_type_idが設定されている
      * - StudyGoalがアクティブ状態
@@ -356,7 +356,7 @@ class StudyGoalController extends Controller
     private function syncExamDateToExamType(StudyGoal $goal, int $userId): void
     {
         // 同期条件：exam_type_idが設定されており、かつアクティブな目標のみ
-        if (!$goal->exam_type_id || !$goal->is_active) {
+        if (! $goal->exam_type_id || ! $goal->is_active) {
             return;
         }
 
@@ -365,17 +365,17 @@ class StudyGoalController extends Controller
             ->first();
 
         // ExamTypeが存在しない、または所有権がない場合は処理しない
-        if (!$examType) {
+        if (! $examType) {
             return;
         }
 
         // 試験日に変更がある場合のみ更新（値ベースの比較）
         $examDate = $examType->exam_date ? $examType->exam_date->toDateString() : null;
         $goalDate = $goal->exam_date ? $goal->exam_date->toDateString() : null;
-        
+
         if ($examDate !== $goalDate) {
             $oldDate = $examType->exam_date;
-            
+
             $examType->update(['exam_date' => $goal->exam_date]);
 
             // ログ出力


### PR DESCRIPTION
## Summary
- 試験タイプ削除時に発生していた500エラー（外部キー制約違反）を修正
- StudyGoalsの事前削除により安全な削除処理を実装
- 詳細ログとユーザーフレンドリーなメッセージを追加

## 問題の詳細
Issue #42 で報告された通り、試験タイプ削除時に外部キー制約違反エラーが発生していました。

### 根本原因
- `study_goals`テーブルの`exam_type_id`にcascade削除が設定されていない
- ExamTypeに関連するStudyGoalが存在する状態で削除を試行すると制約エラーが発生

## 修正内容
1. **外部キー制約エラーの解決**
   - ExamType削除前に関連StudyGoalsを手動削除する処理を追加
   - データベース制約に依存しない安全な削除順序を実装

2. **詳細ログの追加**
   - 削除処理の各段階でログ出力を実装
   - エラー発生時のデバッグが容易になる詳細情報を記録

3. **ユーザーエクスペリエンスの向上**
   - 削除時に何件のStudyGoalも削除されたかを通知
   - より分かりやすいエラーメッセージの提供

## Test plan
- [x] コードフォーマッター（Laravel Pint）実行済み
- [x] 全テストが正常に通過することを確認
- [x] 実際の削除操作で500エラーが解消されることを確認

## 技術的詳細
- UserExamTypeController::destroy()メソッドを強化
- 削除順序: StudyGoals → ExamType（SubjectAreasは既存のcascade削除）
- 認証・権限チェックの改善

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and authentication checks when deleting exam types.
  * Enhanced feedback with detailed success and error messages during deletion.

* **Chores**
  * Improved logging throughout the exam type deletion process for better traceability.
  * Reformatted code and comments for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->