### PR TITLE
feat: ダッシュボードに「目標を達成したあとの自分」セクション追加

### DIFF
--- a/app/Http/Controllers/Api/UserFutureVisionController.php
+++ b/app/Http/Controllers/Api/UserFutureVisionController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UserFutureVisionRequest;
+use App\Models\UserFutureVision;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class UserFutureVisionController extends Controller
+{
+    /**
+     * 将来のビジョンを取得
+     */
+    public function show(Request $request): JsonResponse
+    {
+        $vision = $request->user()->userFutureVision;
+        
+        return response()->json([
+            'success' => true,
+            'data' => $vision
+        ], $vision ? 200 : 204);
+    }
+
+    /**
+     * 将来のビジョンを作成
+     */
+    public function store(UserFutureVisionRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        
+        // 既存のビジョンがある場合は409 Conflictを返す
+        if ($user->userFutureVision) {
+            return response()->json([
+                'success' => false,
+                'message' => '将来のビジョンは既に登録されています。更新する場合はPUTメソッドを使用してください。'
+            ], 409);
+        }
+
+        $vision = UserFutureVision::create([
+            'user_id' => $user->id,
+            'vision_text' => $request->validated()['vision_text']
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => '将来のビジョンを保存しました',
+            'data' => $vision
+        ], 201);
+    }
+
+    /**
+     * 将来のビジョンを更新
+     */
+    public function update(UserFutureVisionRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $vision = $user->userFutureVision;
+        
+        if (!$vision) {
+            return response()->json([
+                'success' => false,
+                'message' => '更新対象の将来のビジョンが見つかりません。'
+            ], 404);
+        }
+
+        $vision->update([
+            'vision_text' => $request->validated()['vision_text']
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => '将来のビジョンを更新しました',
+            'data' => $vision->fresh()
+        ]);
+    }
+
+    /**
+     * 将来のビジョンを削除
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $vision = $user->userFutureVision;
+        
+        if (!$vision) {
+            return response()->json([
+                'success' => false,
+                'message' => '削除対象の将来のビジョンが見つかりません。'
+            ], 404);
+        }
+
+        $vision->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => '将来のビジョンを削除しました'
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/UserFutureVisionController.php
+++ b/app/Http/Controllers/Api/UserFutureVisionController.php
@@ -16,14 +16,14 @@ class UserFutureVisionController extends Controller
     public function show(Request $request): JsonResponse
     {
         $vision = $request->user()->userFutureVision;
-        
-        if (!$vision) {
+
+        if (! $vision) {
             return response()->json([], 204); // 204はボディなし
         }
-        
+
         return response()->json([
             'success' => true,
-            'data' => $vision
+            'data' => $vision,
         ], 200);
     }
 
@@ -33,24 +33,24 @@ class UserFutureVisionController extends Controller
     public function store(UserFutureVisionRequest $request): JsonResponse
     {
         $user = $request->user();
-        
+
         // 既存のビジョンがある場合は409 Conflictを返す
         if ($user->userFutureVision) {
             return response()->json([
                 'success' => false,
-                'message' => '将来のビジョンは既に登録されています。更新する場合はPUTメソッドを使用してください。'
+                'message' => '将来のビジョンは既に登録されています。更新する場合はPUTメソッドを使用してください。',
             ], 409);
         }
 
         $vision = UserFutureVision::create([
             'user_id' => $user->id,
-            'vision_text' => $request->validated()['vision_text']
+            'vision_text' => $request->validated()['vision_text'],
         ]);
 
         return response()->json([
             'success' => true,
             'message' => '将来のビジョンを保存しました',
-            'data' => $vision
+            'data' => $vision,
         ], 201);
     }
 
@@ -61,22 +61,22 @@ class UserFutureVisionController extends Controller
     {
         $user = $request->user();
         $vision = $user->userFutureVision;
-        
-        if (!$vision) {
+
+        if (! $vision) {
             return response()->json([
                 'success' => false,
-                'message' => '更新対象の将来のビジョンが見つかりません。'
+                'message' => '更新対象の将来のビジョンが見つかりません。',
             ], 404);
         }
 
         $vision->update([
-            'vision_text' => $request->validated()['vision_text']
+            'vision_text' => $request->validated()['vision_text'],
         ]);
 
         return response()->json([
             'success' => true,
             'message' => '将来のビジョンを更新しました',
-            'data' => $vision->fresh()
+            'data' => $vision->fresh(),
         ]);
     }
 
@@ -87,11 +87,11 @@ class UserFutureVisionController extends Controller
     {
         $user = $request->user();
         $vision = $user->userFutureVision;
-        
-        if (!$vision) {
+
+        if (! $vision) {
             return response()->json([
                 'success' => false,
-                'message' => '削除対象の将来のビジョンが見つかりません。'
+                'message' => '削除対象の将来のビジョンが見つかりません。',
             ], 404);
         }
 
@@ -99,7 +99,7 @@ class UserFutureVisionController extends Controller
 
         return response()->json([
             'success' => true,
-            'message' => '将来のビジョンを削除しました'
+            'message' => '将来のビジョンを削除しました',
         ]);
     }
 }

--- a/app/Http/Controllers/Api/UserFutureVisionController.php
+++ b/app/Http/Controllers/Api/UserFutureVisionController.php
@@ -17,10 +17,14 @@ class UserFutureVisionController extends Controller
     {
         $vision = $request->user()->userFutureVision;
         
+        if (!$vision) {
+            return response()->json([], 204); // 204はボディなし
+        }
+        
         return response()->json([
             'success' => true,
             'data' => $vision
-        ], $vision ? 200 : 204);
+        ], 200);
     }
 
     /**

--- a/app/Http/Requests/UserFutureVisionRequest.php
+++ b/app/Http/Requests/UserFutureVisionRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserFutureVisionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true; // 認証はミドルウェアで行う
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'vision_text' => [
+                'required',
+                'string',
+                'min:10',                    // 意味ある文章として最低限の長さ
+                'max:2000',                  // ツイートの約10倍程度
+                'regex:/^[^<>&"\']*$/',      // HTML特殊文字を除外（XSS対策）
+            ],
+        ];
+    }
+
+    /**
+     * Get custom error messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'vision_text.required' => '将来のビジョンを入力してください。',
+            'vision_text.string' => '将来のビジョンは文字列で入力してください。',
+            'vision_text.min' => '将来のビジョンは10文字以上で入力してください。',
+            'vision_text.max' => '将来のビジョンは2000文字以内で入力してください。',
+            'vision_text.regex' => '将来のビジョンに使用できない文字が含まれています。',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\DB;
@@ -75,6 +76,11 @@ class User extends Authenticatable
     public function onboardingLogs(): HasMany
     {
         return $this->hasMany(OnboardingLog::class);
+    }
+
+    public function userFutureVision(): HasOne
+    {
+        return $this->hasOne(UserFutureVision::class);
     }
 
     // ヘルパーメソッド

--- a/app/Models/UserFutureVision.php
+++ b/app/Models/UserFutureVision.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserFutureVision extends Model
+{
+    protected $table = 'user_future_visions';
+
+    protected $fillable = [
+        'user_id',
+        'vision_text',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_08_08_235826_create_user_future_visions_table.php
+++ b/database/migrations/2025_08_08_235826_create_user_future_visions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_future_visions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade')->comment('ユーザーID');
+            $table->text('vision_text')->comment('将来のビジョンテキスト');
+            $table->timestamps();
+
+            $table->index('user_id', 'idx_user_future_visions_user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_future_visions');
+    }
+};

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -34,16 +34,16 @@
         
         <!-- 表示モード（データがある場合） -->
         <div v-else-if="futureVision.hasData && !futureVision.isEditing" class="space-y-4">
-          <div class="p-4 rounded-lg text-gray-700 leading-relaxed whitespace-pre-wrap" style="background-color: var(--color-muted-purple-light);">
+          <div class="p-4 rounded-lg text-gray-700 leading-relaxed whitespace-pre-wrap border" style="border-color: var(--color-muted-gray); background-color: transparent;">
             {{ futureVision.text }}
           </div>
           <div class="flex justify-end gap-2">
             <button 
               @click="startEditVision"
-              class="px-3 py-1 text-sm rounded transition-colors"
-              style="color: var(--color-muted-purple-dark); background-color: var(--color-muted-purple-light);"
-              onmouseover="this.style.backgroundColor='var(--color-muted-purple)'; this.style.color='white'"
-              onmouseout="this.style.backgroundColor='var(--color-muted-purple-light)'; this.style.color='var(--color-muted-purple-dark)'"
+              class="px-3 py-1 text-sm text-white rounded transition-colors"
+              style="background-color: var(--color-muted-blue);"
+              onmouseover="this.style.backgroundColor='var(--color-muted-blue-dark)'"
+              onmouseout="this.style.backgroundColor='var(--color-muted-blue)'"
             >
               ✏️ 編集
             </button>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -74,6 +74,9 @@
           <div class="flex justify-between items-center">
             <div class="text-xs text-gray-500">
               {{ futureVision.text.length }}/2000文字
+              <span class="ml-2 text-red-500" v-if="futureVision.text.trim().length < 10">
+                ({{ futureVision.text.trim().length }}文字 - 10文字以上必要)
+              </span>
             </div>
             <div class="flex gap-2">
               <button
@@ -89,11 +92,11 @@
               </button>
               <button
                 @click="saveFutureVision"
-                :disabled="futureVision.loading || futureVision.text.trim().length < 10 || futureVision.text.length > 2000"
+                :disabled="isVisionSaveDisabled"
                 class="px-4 py-2 text-sm text-white rounded transition-colors"
                 :style="{
-                  backgroundColor: (futureVision.loading || futureVision.text.trim().length < 10 || futureVision.text.length > 2000) ? 'var(--color-muted-gray)' : 'var(--color-muted-purple)',
-                  cursor: (futureVision.loading || futureVision.text.trim().length < 10 || futureVision.text.length > 2000) ? 'not-allowed' : 'pointer'
+                  backgroundColor: isVisionSaveDisabled ? 'var(--color-muted-gray)' : 'var(--color-muted-purple)',
+                  cursor: isVisionSaveDisabled ? 'not-allowed' : 'pointer'
                 }"
                 onmouseover="if (!this.disabled) this.style.backgroundColor='var(--color-muted-purple-dark)'"
                 onmouseout="if (!this.disabled) this.style.backgroundColor='var(--color-muted-purple)'"
@@ -438,6 +441,13 @@ export default {
     
     isActive() {
       return this.globalStudyTimer.isActive
+    },
+
+    // 将来ビジョン保存ボタンの無効化条件
+    isVisionSaveDisabled() {
+      return this.futureVision.loading || 
+             this.futureVision.text.trim().length < 10 || 
+             this.futureVision.text.length > 2000
     }
   },
   

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,25 +1,110 @@
 <template>
   <div>
-    <!-- 試験日カウントダウン -->
-    <section v-if="upcomingExams.length > 0" class="rounded-lg shadow p-6 mb-6" style="background-color: white; border: 1px solid var(--color-muted-gray);">
-      <h2 class="text-lg font-semibold mb-4" style="color: var(--color-muted-blue-dark);">🎯 試験予定日まで</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div v-for="exam in upcomingExams" :key="exam.exam_type_name" class="bg-white rounded-lg p-4">
-          <div class="flex justify-between items-center">
-            <div>
-              <div class="font-bold text-lg" style="color: var(--color-muted-blue-dark);">{{ exam.exam_type_name }}</div>
-              <div class="text-sm text-gray-600">{{ formatExamDate(exam.exam_date) }}</div>
-            </div>
-            <div class="text-right">
-              <div class="text-3xl font-bold" :style="{ color: getCountdownColor(exam.days_until_exam) }">
-                {{ exam.days_until_exam }}
+    <!-- 試験日カウントダウン & 将来のビジョン -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+      <!-- 試験日カウントダウンセクション -->
+      <section v-if="upcomingExams.length > 0" class="rounded-lg shadow p-6" style="background-color: white; border: 1px solid var(--color-muted-gray);">
+        <h2 class="text-lg font-semibold mb-4" style="color: var(--color-muted-blue-dark);">🎯 試験予定日まで</h2>
+        <div class="space-y-3">
+          <div v-for="exam in upcomingExams" :key="exam.exam_type_name" class="bg-white rounded-lg p-4 border" style="border-color: var(--color-muted-gray);">
+            <div class="flex justify-between items-center">
+              <div>
+                <div class="font-bold text-lg" style="color: var(--color-muted-blue-dark);">{{ exam.exam_type_name }}</div>
+                <div class="text-sm text-gray-600">{{ formatExamDate(exam.exam_date) }}</div>
               </div>
-              <div class="text-sm text-gray-600">日</div>
+              <div class="text-right">
+                <div class="text-3xl font-bold" :style="{ color: getCountdownColor(exam.days_until_exam) }">
+                  {{ exam.days_until_exam }}
+                </div>
+                <div class="text-sm text-gray-600">日</div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      <!-- 将来のビジョンセクション -->
+      <section class="rounded-lg shadow p-6" style="background-color: white; border: 1px solid var(--color-muted-gray);">
+        <h2 class="text-lg font-semibold mb-4" style="color: var(--color-muted-purple-dark);">✨ 目標を達成したあとの自分</h2>
+        
+        <!-- ローディング表示 -->
+        <div v-if="futureVision.loading" class="text-center py-8">
+          <div class="text-gray-500">読み込み中...</div>
+        </div>
+        
+        <!-- 表示モード（データがある場合） -->
+        <div v-else-if="futureVision.hasData && !futureVision.isEditing" class="space-y-4">
+          <div class="p-4 rounded-lg text-gray-700 leading-relaxed whitespace-pre-wrap" style="background-color: var(--color-muted-purple-light);">
+            {{ futureVision.text }}
+          </div>
+          <div class="flex justify-end gap-2">
+            <button 
+              @click="startEditVision"
+              class="px-3 py-1 text-sm rounded transition-colors"
+              style="color: var(--color-muted-purple-dark); background-color: var(--color-muted-purple-light);"
+              onmouseover="this.style.backgroundColor='var(--color-muted-purple)'; this.style.color='white'"
+              onmouseout="this.style.backgroundColor='var(--color-muted-purple-light)'; this.style.color='var(--color-muted-purple-dark)'"
+            >
+              ✏️ 編集
+            </button>
+            <button 
+              @click="deleteFutureVision"
+              :disabled="futureVision.loading"
+              class="px-3 py-1 text-sm rounded transition-colors"
+              style="color: var(--color-muted-pink-dark); background-color: var(--color-muted-pink-light);"
+              onmouseover="this.style.backgroundColor='var(--color-muted-pink)'; this.style.color='white'"
+              onmouseout="this.style.backgroundColor='var(--color-muted-pink-light)'; this.style.color='var(--color-muted-pink-dark)'"
+            >
+              🗑️ 削除
+            </button>
+          </div>
+        </div>
+        
+        <!-- 入力/編集モード -->
+        <div v-else class="space-y-4">
+          <textarea
+            v-model="futureVision.text"
+            class="w-full p-4 rounded-lg resize-none"
+            style="border: 1px solid var(--color-muted-gray); background-color: white; min-height: 120px;"
+            onfocus="this.style.borderColor='var(--color-muted-purple)'; this.style.boxShadow='0 0 0 2px var(--color-muted-purple-alpha)'"
+            onblur="this.style.borderColor='var(--color-muted-gray)'; this.style.boxShadow='none'"
+            :placeholder="futureVision.hasData ? '将来のビジョンを編集してください...' : '資格を取得した後、どんな自分になりたいですか？将来のビジョンを描いてみましょう...'"
+            rows="6"
+          ></textarea>
+          <div class="flex justify-between items-center">
+            <div class="text-xs text-gray-500">
+              {{ futureVision.text.length }}/2000文字
+            </div>
+            <div class="flex gap-2">
+              <button
+                v-if="futureVision.isEditing"
+                @click="cancelEditVision"
+                :disabled="futureVision.loading"
+                class="px-4 py-2 text-sm rounded transition-colors"
+                style="color: var(--color-muted-gray-dark); background-color: var(--color-muted-gray);"
+                onmouseover="this.style.backgroundColor='var(--color-muted-gray-dark)'; this.style.color='white'"
+                onmouseout="this.style.backgroundColor='var(--color-muted-gray)'; this.style.color='var(--color-muted-gray-dark)'"
+              >
+                キャンセル
+              </button>
+              <button
+                @click="saveFutureVision"
+                :disabled="futureVision.loading || futureVision.text.trim().length < 10 || futureVision.text.length > 2000"
+                class="px-4 py-2 text-sm text-white rounded transition-colors"
+                :style="{
+                  backgroundColor: (futureVision.loading || futureVision.text.trim().length < 10 || futureVision.text.length > 2000) ? 'var(--color-muted-gray)' : 'var(--color-muted-purple)',
+                  cursor: (futureVision.loading || futureVision.text.trim().length < 10 || futureVision.text.length > 2000) ? 'not-allowed' : 'pointer'
+                }"
+                onmouseover="if (!this.disabled) this.style.backgroundColor='var(--color-muted-purple-dark)'"
+                onmouseout="if (!this.disabled) this.style.backgroundColor='var(--color-muted-purple)'"
+              >
+                {{ futureVision.loading ? '保存中...' : '💾 保存' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
 
     <!-- GitHub風草表示 -->
     <section class="rounded-lg shadow p-6 mb-6" style="background-color: white; border: 1px solid var(--color-muted-gray);">
@@ -328,6 +413,15 @@ export default {
         notes: '',
         saving: false
       },
+      
+      // 将来ビジョン関連
+      futureVision: {
+        id: null,
+        text: '',
+        isEditing: false,
+        loading: false,
+        hasData: false
+      },
     }
   },
   
@@ -366,6 +460,9 @@ export default {
     
     // ページの visibility change イベントを監視（タブ切り替えやアプリ切り替え時の対応）
     document.addEventListener('visibilitychange', this.handleVisibilityChange)
+    
+    // 将来ビジョンを読み込み
+    await this.loadFutureVision()
   },
   
   async activated() {
@@ -680,6 +777,137 @@ export default {
         await this.loadDashboardData()
       }
     },
+
+    // ========== 将来ビジョン関連メソッド ==========
+    
+    // 将来ビジョンを読み込み
+    async loadFutureVision() {
+      this.futureVision.loading = true
+      try {
+        const response = await axios.get('/api/user/future-vision', {
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
+          }
+        })
+        
+        if (response.status === 200 && response.data.success) {
+          this.futureVision.id = response.data.data.id
+          this.futureVision.text = response.data.data.vision_text
+          this.futureVision.hasData = true
+        } else {
+          // 204 No Content の場合
+          this.futureVision.id = null
+          this.futureVision.text = ''
+          this.futureVision.hasData = false
+        }
+      } catch (error) {
+        console.error('将来ビジョン読み込みエラー:', error)
+        if (error.response?.status !== 204) {
+          this.showError('将来のビジョンの読み込みに失敗しました')
+        }
+        this.futureVision.id = null
+        this.futureVision.text = ''
+        this.futureVision.hasData = false
+      } finally {
+        this.futureVision.loading = false
+      }
+    },
+    
+    // 将来ビジョンの保存
+    async saveFutureVision() {
+      if (this.futureVision.text.trim().length < 10) {
+        this.showError('将来のビジョンは10文字以上で入力してください')
+        return
+      }
+      
+      if (this.futureVision.text.length > 2000) {
+        this.showError('将来のビジョンは2000文字以内で入力してください')
+        return
+      }
+      
+      this.futureVision.loading = true
+      try {
+        const isUpdate = this.futureVision.hasData
+        const method = isUpdate ? 'put' : 'post'
+        
+        const response = await axios[method]('/api/user/future-vision', {
+          vision_text: this.futureVision.text
+        }, {
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
+          }
+        })
+        
+        if (response.data.success) {
+          this.futureVision.id = response.data.data.id
+          this.futureVision.hasData = true
+          this.futureVision.isEditing = false
+          this.showSuccess(response.data.message)
+        } else {
+          this.showError(response.data.message || '保存に失敗しました')
+        }
+      } catch (error) {
+        console.error('将来ビジョン保存エラー:', error)
+        if (error.response?.data?.message) {
+          this.showError(error.response.data.message)
+        } else {
+          this.showError('将来のビジョンの保存中にエラーが発生しました')
+        }
+      } finally {
+        this.futureVision.loading = false
+      }
+    },
+    
+    // 編集モード開始
+    startEditVision() {
+      this.futureVision.isEditing = true
+    },
+    
+    // 編集キャンセル
+    cancelEditVision() {
+      this.futureVision.isEditing = false
+      // データがある場合は元のテキストに戻す
+      if (this.futureVision.hasData) {
+        this.loadFutureVision()
+      } else {
+        this.futureVision.text = ''
+      }
+    },
+    
+    // 将来ビジョンの削除
+    async deleteFutureVision() {
+      if (!confirm('将来のビジョンを削除してもよろしいですか？')) {
+        return
+      }
+      
+      this.futureVision.loading = true
+      try {
+        const response = await axios.delete('/api/user/future-vision', {
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
+          }
+        })
+        
+        if (response.data.success) {
+          this.futureVision.id = null
+          this.futureVision.text = ''
+          this.futureVision.hasData = false
+          this.futureVision.isEditing = false
+          this.showSuccess(response.data.message)
+        } else {
+          this.showError(response.data.message || '削除に失敗しました')
+        }
+      } catch (error) {
+        console.error('将来ビジョン削除エラー:', error)
+        if (error.response?.data?.message) {
+          this.showError(error.response.data.message)
+        } else {
+          this.showError('将来のビジョンの削除中にエラーが発生しました')
+        }
+      } finally {
+        this.futureVision.loading = false
+      }
+    }
 
   }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\PomodoroController;
 use App\Http\Controllers\Api\StudyAnalyticsController;
 use App\Http\Controllers\Api\StudyGoalController;
 use App\Http\Controllers\Api\StudySessionController;
+use App\Http\Controllers\Api\UserFutureVisionController;
 use Illuminate\Support\Facades\Route;
 
 // 認証が不要なエンドポイント
@@ -30,6 +31,14 @@ Route::middleware('auth:sanctum')->group(function () {
     // ユーザー設定管理
     Route::apiResource('user/exam-types', App\Http\Controllers\Api\UserExamTypeController::class);
     Route::apiResource('user/subject-areas', App\Http\Controllers\Api\UserSubjectAreaController::class);
+
+    // User Future Vision API（将来のビジョン機能）
+    Route::prefix('user')->middleware(['throttle:10,1'])->group(function () {
+        Route::get('/future-vision', [UserFutureVisionController::class, 'show']);
+        Route::post('/future-vision', [UserFutureVisionController::class, 'store']);
+        Route::put('/future-vision', [UserFutureVisionController::class, 'update']);
+        Route::delete('/future-vision', [UserFutureVisionController::class, 'destroy']);
+    });
 
     // Dashboard API（認証済みユーザーのデータのみ）
     Route::get('/dashboard', [DashboardController::class, 'index']);

--- a/tests/Feature/UserFutureVisionTest.php
+++ b/tests/Feature/UserFutureVisionTest.php
@@ -38,7 +38,7 @@ class UserFutureVisionTest extends TestCase
                     'id' => $vision->id,
                     'user_id' => $this->user->id,
                     'vision_text' => '資格を取得して、チームリーダーになる',
-                ]
+                ],
             ]);
     }
 
@@ -66,7 +66,7 @@ class UserFutureVisionTest extends TestCase
 
         $response = $this->actingAs($this->user, 'sanctum')
             ->postJson('/api/user/future-vision', [
-                'vision_text' => $visionText
+                'vision_text' => $visionText,
             ]);
 
         $response->assertStatus(201)
@@ -76,7 +76,7 @@ class UserFutureVisionTest extends TestCase
                 'data' => [
                     'user_id' => $this->user->id,
                     'vision_text' => $visionText,
-                ]
+                ],
             ]);
 
         $this->assertDatabaseHas('user_future_visions', [
@@ -94,13 +94,13 @@ class UserFutureVisionTest extends TestCase
 
         $response = $this->actingAs($this->user, 'sanctum')
             ->postJson('/api/user/future-vision', [
-                'vision_text' => '新しいビジョンテキストを10文字以上で入力'
+                'vision_text' => '新しいビジョンテキストを10文字以上で入力',
             ]);
 
         $response->assertStatus(409)
             ->assertJson([
                 'success' => false,
-                'message' => '将来のビジョンは既に登録されています。更新する場合はPUTメソッドを使用してください。'
+                'message' => '将来のビジョンは既に登録されています。更新する場合はPUTメソッドを使用してください。',
             ]);
     }
 
@@ -116,7 +116,7 @@ class UserFutureVisionTest extends TestCase
         // 最小文字数チェック
         $response = $this->actingAs($this->user, 'sanctum')
             ->postJson('/api/user/future-vision', [
-                'vision_text' => '短い'
+                'vision_text' => '短い',
             ]);
 
         $response->assertStatus(422)
@@ -125,7 +125,7 @@ class UserFutureVisionTest extends TestCase
         // 最大文字数チェック
         $response = $this->actingAs($this->user, 'sanctum')
             ->postJson('/api/user/future-vision', [
-                'vision_text' => str_repeat('あ', 2001)
+                'vision_text' => str_repeat('あ', 2001),
             ]);
 
         $response->assertStatus(422)
@@ -134,7 +134,7 @@ class UserFutureVisionTest extends TestCase
         // HTML特殊文字チェック
         $response = $this->actingAs($this->user, 'sanctum')
             ->postJson('/api/user/future-vision', [
-                'vision_text' => 'テスト<script>alert("xss")</script>'
+                'vision_text' => 'テスト<script>alert("xss")</script>',
             ]);
 
         $response->assertStatus(422)
@@ -154,7 +154,7 @@ class UserFutureVisionTest extends TestCase
 
         $response = $this->actingAs($this->user, 'sanctum')
             ->putJson('/api/user/future-vision', [
-                'vision_text' => $newVisionText
+                'vision_text' => $newVisionText,
             ]);
 
         $response->assertStatus(200)
@@ -165,7 +165,7 @@ class UserFutureVisionTest extends TestCase
                     'id' => $vision->id,
                     'user_id' => $this->user->id,
                     'vision_text' => $newVisionText,
-                ]
+                ],
             ]);
 
         $this->assertDatabaseHas('user_future_visions', [
@@ -178,13 +178,13 @@ class UserFutureVisionTest extends TestCase
     {
         $response = $this->actingAs($this->user, 'sanctum')
             ->putJson('/api/user/future-vision', [
-                'vision_text' => '更新テストで10文字以上にする'
+                'vision_text' => '更新テストで10文字以上にする',
             ]);
 
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => '更新対象の将来のビジョンが見つかりません。'
+                'message' => '更新対象の将来のビジョンが見つかりません。',
             ]);
     }
 
@@ -203,7 +203,7 @@ class UserFutureVisionTest extends TestCase
         $response->assertStatus(200)
             ->assertJson([
                 'success' => true,
-                'message' => '将来のビジョンを削除しました'
+                'message' => '将来のビジョンを削除しました',
             ]);
 
         $this->assertDatabaseMissing('user_future_visions', [
@@ -219,7 +219,7 @@ class UserFutureVisionTest extends TestCase
         $response->assertStatus(404)
             ->assertJson([
                 'success' => false,
-                'message' => '削除対象の将来のビジョンが見つかりません。'
+                'message' => '削除対象の将来のビジョンが見つかりません。',
             ]);
     }
 }

--- a/tests/Feature/UserFutureVisionTest.php
+++ b/tests/Feature/UserFutureVisionTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserFutureVision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserFutureVisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    // GET /api/user/future-vision のテスト
+
+    public function test_can_get_future_vision_when_exists(): void
+    {
+        $vision = UserFutureVision::create([
+            'user_id' => $this->user->id,
+            'vision_text' => '資格を取得して、チームリーダーになる',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson('/api/user/future-vision');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data' => [
+                    'id' => $vision->id,
+                    'user_id' => $this->user->id,
+                    'vision_text' => '資格を取得して、チームリーダーになる',
+                ]
+            ]);
+    }
+
+    public function test_returns_204_when_no_future_vision_exists(): void
+    {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson('/api/user/future-vision');
+
+        $response->assertStatus(204);
+        // 204 No Content はレスポンスボディを持たない
+    }
+
+    public function test_cannot_get_future_vision_without_authentication(): void
+    {
+        $response = $this->getJson('/api/user/future-vision');
+
+        $response->assertStatus(401);
+    }
+
+    // POST /api/user/future-vision のテスト
+
+    public function test_can_create_future_vision(): void
+    {
+        $visionText = 'AWS認定を取得して、クラウドエキスパートになりたい';
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/user/future-vision', [
+                'vision_text' => $visionText
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'success' => true,
+                'message' => '将来のビジョンを保存しました',
+                'data' => [
+                    'user_id' => $this->user->id,
+                    'vision_text' => $visionText,
+                ]
+            ]);
+
+        $this->assertDatabaseHas('user_future_visions', [
+            'user_id' => $this->user->id,
+            'vision_text' => $visionText,
+        ]);
+    }
+
+    public function test_cannot_create_future_vision_when_already_exists(): void
+    {
+        UserFutureVision::create([
+            'user_id' => $this->user->id,
+            'vision_text' => '既存のビジョン',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/user/future-vision', [
+                'vision_text' => '新しいビジョンテキストを10文字以上で入力'
+            ]);
+
+        $response->assertStatus(409)
+            ->assertJson([
+                'success' => false,
+                'message' => '将来のビジョンは既に登録されています。更新する場合はPUTメソッドを使用してください。'
+            ]);
+    }
+
+    public function test_validates_vision_text_on_create(): void
+    {
+        // 必須チェック
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/user/future-vision', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['vision_text']);
+
+        // 最小文字数チェック
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/user/future-vision', [
+                'vision_text' => '短い'
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['vision_text']);
+
+        // 最大文字数チェック
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/user/future-vision', [
+                'vision_text' => str_repeat('あ', 2001)
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['vision_text']);
+
+        // HTML特殊文字チェック
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/user/future-vision', [
+                'vision_text' => 'テスト<script>alert("xss")</script>'
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['vision_text']);
+    }
+
+    // PUT /api/user/future-vision のテスト
+
+    public function test_can_update_future_vision(): void
+    {
+        $vision = UserFutureVision::create([
+            'user_id' => $this->user->id,
+            'vision_text' => '古いビジョン',
+        ]);
+
+        $newVisionText = '更新されたビジョンテキスト';
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson('/api/user/future-vision', [
+                'vision_text' => $newVisionText
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'message' => '将来のビジョンを更新しました',
+                'data' => [
+                    'id' => $vision->id,
+                    'user_id' => $this->user->id,
+                    'vision_text' => $newVisionText,
+                ]
+            ]);
+
+        $this->assertDatabaseHas('user_future_visions', [
+            'id' => $vision->id,
+            'vision_text' => $newVisionText,
+        ]);
+    }
+
+    public function test_cannot_update_nonexistent_future_vision(): void
+    {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson('/api/user/future-vision', [
+                'vision_text' => '更新テストで10文字以上にする'
+            ]);
+
+        $response->assertStatus(404)
+            ->assertJson([
+                'success' => false,
+                'message' => '更新対象の将来のビジョンが見つかりません。'
+            ]);
+    }
+
+    // DELETE /api/user/future-vision のテスト
+
+    public function test_can_delete_future_vision(): void
+    {
+        $vision = UserFutureVision::create([
+            'user_id' => $this->user->id,
+            'vision_text' => '削除対象のビジョン',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->deleteJson('/api/user/future-vision');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'message' => '将来のビジョンを削除しました'
+            ]);
+
+        $this->assertDatabaseMissing('user_future_visions', [
+            'id' => $vision->id,
+        ]);
+    }
+
+    public function test_cannot_delete_nonexistent_future_vision(): void
+    {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->deleteJson('/api/user/future-vision');
+
+        $response->assertStatus(404)
+            ->assertJson([
+                'success' => false,
+                'message' => '削除対象の将来のビジョンが見つかりません。'
+            ]);
+    }
+}

--- a/tests/Unit/Models/UserFutureVisionTest.php
+++ b/tests/Unit/Models/UserFutureVisionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\User;
+use App\Models\UserFutureVision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserFutureVisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_future_vision_can_be_created()
+    {
+        $user = User::factory()->create();
+        
+        $futureVision = UserFutureVision::create([
+            'user_id' => $user->id,
+            'vision_text' => 'SnÆ¹ÈoenÓ¸çó’\gM‹Sh’ºW~Y',
+        ]);
+
+        $this->assertDatabaseHas('user_future_visions', [
+            'id' => $futureVision->id,
+            'user_id' => $user->id,
+            'vision_text' => 'SnÆ¹ÈoenÓ¸çó’\gM‹Sh’ºW~Y',
+        ]);
+    }
+
+    public function test_user_future_vision_belongs_to_user()
+    {
+        $user = User::factory()->create();
+        $futureVision = UserFutureVision::create([
+            'user_id' => $user->id,
+            'vision_text' => 'SnÆ¹Èoæü¶üêìü·çó’ºW~Y',
+        ]);
+
+        $this->assertInstanceOf(User::class, $futureVision->user);
+        $this->assertEquals($user->id, $futureVision->user->id);
+    }
+
+    public function test_user_has_one_future_vision()
+    {
+        $user = User::factory()->create();
+        $futureVision = UserFutureVision::create([
+            'user_id' => $user->id,
+            'vision_text' => 'SnÆ¹ÈoUserK‰nêìü·çó’ºW~Y',
+        ]);
+
+        $this->assertInstanceOf(UserFutureVision::class, $user->userFutureVision);
+        $this->assertEquals($futureVision->id, $user->userFutureVision->id);
+    }
+
+    public function test_user_future_vision_has_correct_fillable_fields()
+    {
+        $futureVision = new UserFutureVision();
+        $expectedFillable = [
+            'user_id',
+            'vision_text',
+        ];
+
+        $this->assertEquals($expectedFillable, $futureVision->getFillable());
+    }
+
+    public function test_user_future_vision_has_correct_table_name()
+    {
+        $futureVision = new UserFutureVision();
+        $this->assertEquals('user_future_visions', $futureVision->getTable());
+    }
+
+    public function test_user_future_vision_casts_timestamps()
+    {
+        $user = User::factory()->create();
+        $futureVision = UserFutureVision::create([
+            'user_id' => $user->id,
+            'vision_text' => 'SnÆ¹Èo¿¤à¹¿ó×n­ã¹È’ºW~Y',
+        ]);
+
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $futureVision->created_at);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $futureVision->updated_at);
+    }
+}

--- a/tests/Unit/Models/UserFutureVisionTest.php
+++ b/tests/Unit/Models/UserFutureVisionTest.php
@@ -14,7 +14,7 @@ class UserFutureVisionTest extends TestCase
     public function test_user_future_vision_can_be_created()
     {
         $user = User::factory()->create();
-        
+
         $futureVision = UserFutureVision::create([
             'user_id' => $user->id,
             'vision_text' => 'SnÆ¹ÈoenÓ¸çó’\gM‹Sh’ºW~Y',
@@ -53,7 +53,7 @@ class UserFutureVisionTest extends TestCase
 
     public function test_user_future_vision_has_correct_fillable_fields()
     {
-        $futureVision = new UserFutureVision();
+        $futureVision = new UserFutureVision;
         $expectedFillable = [
             'user_id',
             'vision_text',
@@ -64,7 +64,7 @@ class UserFutureVisionTest extends TestCase
 
     public function test_user_future_vision_has_correct_table_name()
     {
-        $futureVision = new UserFutureVision();
+        $futureVision = new UserFutureVision;
         $this->assertEquals('user_future_visions', $futureVision->getTable());
     }
 

--- a/ui_preview.html
+++ b/ui_preview.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FutureVision & StudyObstacle UI Preview</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body { font-family: 'Hiragino Sans', 'ヒラギノ角ゴシック', 'Yu Gothic', '游ゴシック', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-100 p-6">
+    <div class="max-w-6xl mx-auto">
+        <h1 class="text-3xl font-bold text-gray-800 mb-8 text-center">FutureVision & StudyObstacle UI Preview</h1>
+        
+        <!-- 将来像機能のUI -->
+        <section class="mb-12">
+            <h2 class="text-2xl font-bold text-gray-800 mb-6">🎯 将来像機能</h2>
+            
+            <div class="future-vision-card bg-white rounded-lg shadow-md p-6 mb-4">
+                <!-- ヘッダー部分 -->
+                <div class="vision-header flex justify-between items-center mb-4">
+                    <h3 class="text-xl font-bold text-gray-800">AWS認定ソリューションアーキテクト取得</h3>
+                    <div class="priority-badge bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm">
+                        優先度: 5
+                    </div>
+                </div>
+                
+                <!-- キャリアメリット -->
+                <div class="career-benefits mb-4">
+                    <h4 class="text-lg font-semibold text-gray-700 mb-2">💼 キャリアメリット</h4>
+                    <div class="salary-increase text-green-600 font-bold mb-2">
+                        年収アップ: +¥1,200,000
+                    </div>
+                    <div class="position-upgrade text-blue-600 mb-2">
+                        昇進: シニアエンジニア → テックリード
+                    </div>
+                    <div class="company-opportunities text-purple-600">
+                        転職機会: GAFAM・外資系企業への転職可能性
+                    </div>
+                </div>
+                
+                <!-- 個人的メリット -->
+                <div class="personal-benefits mb-4">
+                    <h4 class="text-lg font-semibold text-gray-700 mb-2">🌟 個人的メリット</h4>
+                    <div class="benefits-list">
+                        <span class="inline-block bg-yellow-100 text-yellow-800 px-2 py-1 rounded mr-2 mb-2 text-sm">
+                            技術力向上
+                        </span>
+                        <span class="inline-block bg-yellow-100 text-yellow-800 px-2 py-1 rounded mr-2 mb-2 text-sm">
+                            クラウド設計スキル
+                        </span>
+                        <span class="inline-block bg-yellow-100 text-yellow-800 px-2 py-1 rounded mr-2 mb-2 text-sm">
+                            業界での認知度アップ
+                        </span>
+                        <span class="inline-block bg-yellow-100 text-yellow-800 px-2 py-1 rounded mr-2 mb-2 text-sm">
+                            自信向上
+                        </span>
+                    </div>
+                </div>
+                
+                <!-- アクションボタン -->
+                <div class="action-buttons flex space-x-2">
+                    <button class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded transition">
+                        編集
+                    </button>
+                    <button class="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded transition">
+                        無効化
+                    </button>
+                </div>
+            </div>
+
+            <!-- 2つ目の将来像カード -->
+            <div class="future-vision-card bg-white rounded-lg shadow-md p-6 mb-4">
+                <div class="vision-header flex justify-between items-center mb-4">
+                    <h3 class="text-xl font-bold text-gray-800">JSTQB Foundation Level 合格</h3>
+                    <div class="priority-badge bg-green-100 text-green-800 px-2 py-1 rounded-full text-sm">
+                        優先度: 3
+                    </div>
+                </div>
+                
+                <div class="career-benefits mb-4">
+                    <h4 class="text-lg font-semibold text-gray-700 mb-2">💼 キャリアメリット</h4>
+                    <div class="salary-increase text-green-600 font-bold mb-2">
+                        年収アップ: +¥300,000
+                    </div>
+                    <div class="position-upgrade text-blue-600 mb-2">
+                        昇進: 品質保証チームリーダー候補
+                    </div>
+                </div>
+                
+                <div class="personal-benefits mb-4">
+                    <h4 class="text-lg font-semibold text-gray-700 mb-2">🌟 個人的メリット</h4>
+                    <div class="benefits-list">
+                        <span class="inline-block bg-yellow-100 text-yellow-800 px-2 py-1 rounded mr-2 mb-2 text-sm">
+                            テスト知識体系化
+                        </span>
+                        <span class="inline-block bg-yellow-100 text-yellow-800 px-2 py-1 rounded mr-2 mb-2 text-sm">
+                            品質意識向上
+                        </span>
+                    </div>
+                </div>
+                
+                <div class="action-buttons flex space-x-2">
+                    <button class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded transition">
+                        編集
+                    </button>
+                    <button class="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded transition">
+                        無効化
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <!-- 障害管理機能のUI -->
+        <section>
+            <h2 class="text-2xl font-bold text-gray-800 mb-6">🚧 障害管理機能</h2>
+            
+            <!-- フィルター -->
+            <div class="filters mb-6 flex space-x-4">
+                <select class="border rounded px-3 py-2">
+                    <option value="">全カテゴリ</option>
+                    <option value="time">時間管理</option>
+                    <option value="motivation">モチベーション</option>
+                    <option value="difficulty">学習難易度</option>
+                    <option value="environment">環境</option>
+                    <option value="health">健康</option>
+                    <option value="other">その他</option>
+                </select>
+                
+                <select class="border rounded px-3 py-2">
+                    <option value="false">未解決のみ</option>
+                    <option value="true">解決済みのみ</option>
+                    <option value="">全て</option>
+                </select>
+            </div>
+            
+            <!-- 障害一覧 -->
+            <div class="obstacles-grid grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <!-- 高深刻度の障害 -->
+                <div class="obstacle-card bg-white rounded-lg shadow-md p-4">
+                    <div class="obstacle-header flex justify-between items-start mb-3">
+                        <h4 class="text-lg font-bold text-gray-800">学習時間の確保ができない</h4>
+                        <span class="severity-badge px-2 py-1 rounded text-xs font-bold bg-red-100 text-red-800">
+                            深刻度: 5
+                        </span>
+                    </div>
+                    
+                    <div class="obstacle-description text-gray-600 mb-3">
+                        平日は残業が多く、休日は家族との時間でまとまった学習時間が取れない
+                    </div>
+                    
+                    <div class="solution-section bg-blue-50 p-3 rounded mb-3">
+                        <h5 class="text-md font-semibold text-blue-800 mb-2">💡 対策</h5>
+                        <p class="text-blue-700 font-medium mb-2">朝活と隙間時間活用法</p>
+                        <div class="solution-steps">
+                            <div class="step text-sm text-blue-600 mb-1">
+                                1. 朝6時起床で1時間学習時間確保
+                            </div>
+                            <div class="step text-sm text-blue-600 mb-1">
+                                2. 通勤時間にスマホで問題集
+                            </div>
+                            <div class="step text-sm text-blue-600 mb-1">
+                                3. 昼休憩の30分を学習に充てる
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="actions flex space-x-2">
+                        <button class="bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded text-sm transition">
+                            解決済みにする
+                        </button>
+                        <button class="bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-1 rounded text-sm transition">
+                            効果を評価
+                        </button>
+                        <button class="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm transition">
+                            編集
+                        </button>
+                    </div>
+                </div>
+
+                <!-- 中深刻度の障害 -->
+                <div class="obstacle-card bg-white rounded-lg shadow-md p-4">
+                    <div class="obstacle-header flex justify-between items-start mb-3">
+                        <h4 class="text-lg font-bold text-gray-800">モチベーション維持が困難</h4>
+                        <span class="severity-badge px-2 py-1 rounded text-xs font-bold bg-yellow-100 text-yellow-800">
+                            深刻度: 3
+                        </span>
+                    </div>
+                    
+                    <div class="obstacle-description text-gray-600 mb-3">
+                        試験まで長期間のため、途中でやる気が下がってしまう
+                    </div>
+                    
+                    <div class="solution-section bg-blue-50 p-3 rounded mb-3">
+                        <h5 class="text-md font-semibold text-blue-800 mb-2">💡 対策</h5>
+                        <p class="text-blue-700 font-medium mb-2">小目標設定とご褒美システム</p>
+                        <div class="solution-steps">
+                            <div class="step text-sm text-blue-600 mb-1">
+                                1. 月次の小目標を設定
+                            </div>
+                            <div class="step text-sm text-blue-600 mb-1">
+                                2. 達成時の自分へのご褒美を決める
+                            </div>
+                            <div class="step text-sm text-blue-600 mb-1">
+                                3. 学習仲間と進捗共有
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="actions flex space-x-2">
+                        <button class="bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded text-sm transition">
+                            解決済みにする
+                        </button>
+                        <button class="bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-1 rounded text-sm transition">
+                            効果を評価
+                        </button>
+                        <button class="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm transition">
+                            編集
+                        </button>
+                    </div>
+                </div>
+
+                <!-- 解決済みの障害 -->
+                <div class="obstacle-card bg-white rounded-lg shadow-md p-4 opacity-60">
+                    <div class="obstacle-header flex justify-between items-start mb-3">
+                        <h4 class="text-lg font-bold text-gray-800">参考書選びで迷った</h4>
+                        <span class="severity-badge px-2 py-1 rounded text-xs font-bold bg-green-100 text-green-800">
+                            深刻度: 2
+                        </span>
+                    </div>
+                    
+                    <div class="obstacle-description text-gray-600 mb-3">
+                        どの参考書が自分に合うかわからず、書店で悩む時間が長かった
+                    </div>
+                    
+                    <div class="solution-section bg-blue-50 p-3 rounded mb-3">
+                        <h5 class="text-md font-semibold text-blue-800 mb-2">💡 対策</h5>
+                        <p class="text-blue-700 font-medium mb-2">レビューサイト調査と試し読み</p>
+                        <div class="solution-steps">
+                            <div class="step text-sm text-blue-600 mb-1">
+                                1. Amazonレビューを詳細に確認
+                            </div>
+                            <div class="step text-sm text-blue-600 mb-1">
+                                2. 技術ブログの書評記事をチェック
+                            </div>
+                            <div class="step text-sm text-blue-600 mb-1">
+                                3. 書店で実際に中身を確認
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="actions flex space-x-2">
+                        <button class="bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-1 rounded text-sm transition">
+                            効果を評価
+                        </button>
+                        <button class="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm transition">
+                            編集
+                        </button>
+                        <span class="text-green-600 text-sm font-medium">✅ 解決済み</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 追加情報 -->
+        <footer class="mt-12 text-center text-gray-500 text-sm">
+            <p>このプレビューは設計書に基づいて作成されました</p>
+            <p>実際の実装時には Vue.js コンポーネント化とデータバインディングが追加されます</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
ダッシュボードに「目標を達成したあとの自分」機能を追加しました。ユーザーが将来のビジョンを自由記述できるフリーテキスト機能です。

### ✨ 新機能
- **レスポンシブ2カラムレイアウト**: デスクトップでは試験予定日と横並び、モバイルでは縦並び
- **完全なCRUD機能**: 作成・表示・編集・削除の全操作対応
- **バリデーション**: 10-2000文字制限、XSS対策済み
- **UX最適化**: リアルタイム文字数カウンター、ローディング状態、エラーハンドリング

### 🏗️ 技術実装
**バックエンド:**
- `user_future_visions`テーブル（CASCADE削除、インデックス最適化）
- UserFutureVisionモデルとUserリレーション
- RESTful API（GET/POST/PUT/DELETE）
- FormRequestバリデーション（XSS対策、文字数制限）
- レート制限（10回/分）

**フロントエンド:**
- Vue.js Options APIでDashboard.vue内に実装
- TailwindCSSレスポンシブデザイン
- 状態管理（ローディング/表示/編集モード）
- 適切なエラーハンドリングとユーザーフィードバック

### 🧪 テスト完備
- **ユニットテスト（6個）**: モデル、リレーション、属性テスト
- **Featureテスト（10個）**: API CRUD、認証、バリデーションテスト
- **TDD開発**: テストファーストで実装
- 全16テスト実行成功

### 🔒 セキュリティ対策
- HTML特殊文字除外の正規表現
- レート制限でスパム防止
- 認証必須、ユーザー所有データのみアクセス可能
- Laravel Sanctumトークン認証

### 📱 デザイン仕様
- 試験予定日セクションと2カラム配置
- 編集ボタンは学習開始ボタンと統一された青色
- 透明背景でクリーンなデザイン
- モバイルファーストレスポンシブ対応

## Test plan
- [x] 全テスト実行成功（16/16）
- [x] Laravel Pint コードフォーマット適用
- [x] 開発サーバーでの動作確認完了
- [x] レスポンシブデザイン確認
- [x] CRUD機能の動作確認
- [x] バリデーション動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)