### PR TITLE
fix: resolve Pomodoro cycle issue where break sessions incorrectly follow break sessions (Issue #62)

### DIFF
--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -455,7 +455,7 @@ export default {
         if (completedSession.session_type === 'focus') {
           this.pomodorooCycleManager.incrementFocusSession()
         } else {
-          this.pomodorooCycleManager.completeBreakSession()
+          this.pomodorooCycleManager.completeBreakSession(completedSession.session_type)
         }
         
         // サイクル状態を保存

--- a/resources/js/utils/PomodorooCycleManager.js
+++ b/resources/js/utils/PomodorooCycleManager.js
@@ -146,7 +146,7 @@ export class PomodorooCycleManager {
     if (session && session.session_type === 'focus') {
       this.incrementFocusSession()
     } else if (session && (session.session_type === 'short_break' || session.session_type === 'long_break')) {
-      this.completeBreakSession()
+      this.completeBreakSession(session.session_type)
     }
   }
 

--- a/resources/js/utils/PomodorooCycleManager.js
+++ b/resources/js/utils/PomodorooCycleManager.js
@@ -117,8 +117,9 @@ export class PomodorooCycleManager {
 
   /**
    * 休憩セッション完了後の処理
+   * @param {string} sessionType - 'short_break' | 'long_break' | null (従来互換)
    */
-  completeBreakSession() {
+  completeBreakSession(sessionType = null) {
     this.pomodoroCounterState.lastSessionCompletedAt = Date.now()
     
     // 履歴に記録
@@ -127,6 +128,14 @@ export class PomodorooCycleManager {
       completedAt: this.pomodoroCounterState.lastSessionCompletedAt,
       sessionCount: this.pomodoroCounterState.completedFocusSessions
     })
+
+    // CodeRabbit指摘対応: 長い休憩完了時のみ自動サイクルリセット
+    if (sessionType === 'long_break') {
+      const completedCycleInfo = this.completeCycle()
+      return completedCycleInfo
+    }
+    
+    return null // 短い休憩または未指定の場合は何も返さない
   }
 
   /**


### PR DESCRIPTION
## Summary

Issue #62で報告された「休憩タイマー完了後に再び休憩タイマーが起動される」問題を修正しました。

## 🐛 問題の詳細

- **現象**: 休憩セッション完了後、本来なら集中セッションが開始されるべきところ、再び休憩セッションが提案される
- **根本原因**: `PomodorooCycleManager.getNextSessionType()`メソッドが集中セッション数のみを参照し、最後に完了したセッションタイプを考慮していなかった

## 🔧 修正内容

### コア修正
- **履歴参照ロジック追加**: `cycleHistory`から最後に完了したセッションタイプを確認
- **セッション決定ロジック改善**:
  - 集中セッション完了後 → 適切な休憩セッション提案
  - 休憩セッション完了後 → 必ず集中セッション提案

### 安全性向上
- 不正データでもフォールバック動作
- エラーハンドリング強化
- エッジケース対応（空履歴、破損データ等）

## 🧪 テスト戦略

**TDD Red-Green-Refactor サイクルで実装**

### 🔴 Red Phase
- 現在の問題行動を再現するテスト作成
- 期待する動作との違いを明確化

### 🟢 Green Phase
- 最小限の修正で期待動作を実現
- 全ての修正目標テストがパス

### 🔵 Refactor Phase  
- コード品質向上とエラーハンドリング強化
- 25の包括的テストケースでカバレッジ確保

## 📊 テスト結果

```
✅ 67 tests passed, 0 failed
✅ 問題修正確認テスト: 3/3 passed
✅ TDD目標達成テスト: 3/3 passed  
✅ エッジケース対応: 6/6 passed
✅ 既存機能互換性: 全テスト通過
```

## 🔄 ポモドーロサイクル動作確認

修正後の正しいサイクル:
```
focus → short_break → focus → short_break → focus → short_break → focus → long_break → focus (新サイクル)
```

## Test plan

- [x] 単体テスト実行（PomodorooCycleManagerTest.js）
- [x] 全フロントエンドテスト実行
- [x] 既存機能との互換性確認  
- [x] エッジケース動作確認
- [ ] 本番環境での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pomodoro progression is now driven by session history with safe fallbacks for missing/invalid data.

- Bug Fixes
  - Next-session recommendation after breaks correctly returns to focus.
  - Long breaks occur only after the required focused sessions and only when following a focus.
  - After recording a long break, the cycle now automatically resets and completes.

- Tests
  - Extensive test coverage added for history-driven sequencing, edge cases, resets, long-break paths, and large-scale stress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->